### PR TITLE
Fix error: call of overloaded 'write(int)' is ambiguous

### DIFF
--- a/NexStarAdapter.ino
+++ b/NexStarAdapter.ino
@@ -568,8 +568,8 @@ void cmdGetTime(char *cmd)
     Serial.write(month(t));
     Serial.write(day(t));
     Serial.write(year(t) % 2000);
-    Serial.write(0);
-    Serial.write(0);
+    Serial.write((byte)0);
+    Serial.write((byte)0);
     Serial.write("#");
 }
 


### PR DESCRIPTION
Compiling NexStarAdapter on Debian gcc version 8.3.0 (Debian 8.3.0-6)
results in error:

NexStarAdapter.ino:571:19: error: call of overloaded 'write(int)' is ambiguous
     Serial.write(0);
                   ^
In file included from /home/tstibor/dev/atmega/arduino/arduino-1.8.9/hardware/arduino/avr/cores/arduino/Arduino.h:233:0,
                 from <command-line>:0:
/home/tstibor/dev/atmega/arduino/arduino-1.8.9/hardware/arduino/avr/cores/arduino/USBAPI.h:103:17: note: candidate: virtual size_t Serial_::write(uint8_t)
  virtual size_t write(uint8_t);

because 0 is handled as pointer literal.